### PR TITLE
Reduce pthread stack size to 512 KB to prevent virtual address space bloat

### DIFF
--- a/proclib.c
+++ b/proclib.c
@@ -1419,6 +1419,7 @@ void *cb_arg)
    struct thread_data *data = malloc(sizeof(struct thread_data));
    data->cb_fcn = cb_fcn;
    data->cb_arg = cb_arg;
+   pthread_attr_t attr;
 
    //create pipe
    int fd[2];
@@ -1433,7 +1434,13 @@ void *cb_arg)
    data->fcn = fcn_ptr;
    data->fcn_arg = arg;
 
-   if(pthread_create(&data->thread, NULL, thread_main, data)){
+   if (pthread_attr_init(&attr) != 0)
+      goto cleanup;
+ 
+   if (pthread_attr_setstacksize(&attr, 0x80000) != 0)
+      goto cleanup;
+
+   if(pthread_create(&data->thread, &attr, thread_main, data)){
       //error creating thread
       goto cleanup;
    }


### PR DESCRIPTION
The default pthread stack size for new threads is 8 MB, which leads to large virtual address spaces. Although the full 8 MB isn't actually allocated on thread creation, info from `top` becomes very non-representative, as `top` reports the virtual address space size instead of actual memory usage. Reducing the stack size will make `top` more useful.