### PR TITLE
Fix gcc format-truncation warning

### DIFF
--- a/Make.rules.Linux
+++ b/Make.rules.Linux
@@ -1,3 +1,3 @@
 SO_EXT=so
-SO_CFLAGS=-fPIC -O -Wno-error=unused-result -Wno-error=deprecated-declarations
+SO_CFLAGS=-fPIC -O -Wno-error=unused-result -Wno-error=deprecated-declarations -Wno-error=format-truncation
 SO_LDFLAGS=-shared -fPIC -Wl,-soname,$(SO_NAME)


### PR DESCRIPTION
GCC 8 warns about truncating in `snprintf`. We are deliberately truncating this buffer, so we're ignoring this.