### PR TITLE
Revert "Fix gcc format-truncation warning"

### DIFF
--- a/Make.rules.Linux
+++ b/Make.rules.Linux
@@ -1,3 +1,3 @@
 SO_EXT=so
-SO_CFLAGS=-fPIC -O -Wno-error=unused-result -Wno-error=deprecated-declarations -Wno-error=format-truncation
+SO_CFLAGS=-fPIC -O -Wno-error=unused-result -Wno-error=deprecated-declarations
 SO_LDFLAGS=-shared -fPIC -Wl,-soname,$(SO_NAME)


### PR DESCRIPTION
Reverts PolySat/libproc#15

It turns out that this flag isn't supported on older versions of gcc. When we officially upgrade all our machines to 18.04 we can look into merging this in.