### PR TITLE
add semicolons missing on lines 59 and 60 of eventTimer.c

### DIFF
--- a/eventTimer.c
+++ b/eventTimer.c
@@ -56,8 +56,8 @@ int ET_default_monotonic(struct EventTimer *et, struct timeval *tv)
 
    #ifdef __APPLE__
 
-   res = 0
-   gettimeofday(tv, NULL)
+   res = 0;
+   gettimeofday(tv, NULL);
 
    #else
 


### PR DESCRIPTION
While checking out the debugger on my Mac, I ran `make install` and I found these missing :+1: