### PR TITLE
Fix issues found when building libproc on mission server

### DIFF
--- a/cmd.h
+++ b/cmd.h
@@ -135,10 +135,16 @@ struct CMD_XDRCommandInfo {
    void *arg;
 };
 
+#ifndef XDR_PRINT_STYLE_ENUM
+#define XDR_PRINT_STYLE_ENUM
 #ifdef __cplusplus
-enum XDR_PRINT_STYLE : short;
+enum XDR_PRINT_STYLE : short { XDR_PRINT_HUMAN, XDR_PRINT_KVP, XDR_PRINT_CSV_HEADER,
+   XDR_PRINT_CSV_DATA };
+
 #else
-enum XDR_PRINT_STYLE;
+enum XDR_PRINT_STYLE { XDR_PRINT_HUMAN, XDR_PRINT_KVP, XDR_PRINT_CSV_HEADER,
+   XDR_PRINT_CSV_DATA };
+#endif
 #endif
 
 extern void CMD_register_commands(struct CMD_XDRCommandInfo*, int);

--- a/events.h
+++ b/events.h
@@ -74,6 +74,8 @@ typedef struct EventState EVTHandler;
  * @return The event handler.
  */
 EVTHandler *EVT_create_handler(EVT_debug_state_cb debug_cb, void *arg);
+struct EventState *EVT_initWithSize(int hashSize, EVT_debug_state_cb debug_cb,
+        void *arg);
 
 /**
  * Free an event handler.

--- a/priorityQueue.c
+++ b/priorityQueue.c
@@ -25,17 +25,17 @@
 #define parent(i) ((i) >> 1)
 
 
-pqueue_t *
-pqueue_init(size_t n,
-            pqueue_cmp_pri_f cmppri,
-            pqueue_get_pri_f getpri,
-            pqueue_set_pri_f setpri,
-            pqueue_get_pos_f getpos,
-            pqueue_set_pos_f setpos)
+ps_pqueue_t *
+ps_pqueue_init(size_t n,
+            ps_pqueue_cmp_pri_f cmppri,
+            ps_pqueue_get_pri_f getpri,
+            ps_pqueue_set_pri_f setpri,
+            ps_pqueue_get_pos_f getpos,
+            ps_pqueue_set_pos_f setpos)
 {
-    pqueue_t *q;
+    ps_pqueue_t *q;
 
-    if (!(q = malloc(sizeof(pqueue_t))))
+    if (!(q = malloc(sizeof(ps_pqueue_t))))
         return NULL;
 
     /* Need to allocate n+1 elements since element 0 isn't used. */
@@ -57,7 +57,7 @@ pqueue_init(size_t n,
 
 
 void
-pqueue_free(pqueue_t *q)
+ps_pqueue_free(ps_pqueue_t *q)
 {
     free(q->d);
     free(q);
@@ -65,7 +65,7 @@ pqueue_free(pqueue_t *q)
 
 
 size_t
-pqueue_size(pqueue_t *q)
+ps_pqueue_size(ps_pqueue_t *q)
 {
     /* queue element 0 exists but doesn't count since it isn't used. */
     return (q->size - 1);
@@ -73,11 +73,11 @@ pqueue_size(pqueue_t *q)
 
 
 static void
-bubble_up(pqueue_t *q, size_t i)
+bubble_up(ps_pqueue_t *q, size_t i)
 {
     size_t parent_node;
     void *moving_node = q->d[i];
-    pqueue_pri_t moving_pri = q->getpri(moving_node);
+    ps_pqueue_pri_t moving_pri = q->getpri(moving_node);
 
     for (parent_node = parent(i);
          ((i > 1) && q->cmppri(q->getpri(q->d[parent_node]), moving_pri));
@@ -93,7 +93,7 @@ bubble_up(pqueue_t *q, size_t i)
 
 
 static size_t
-maxchild(pqueue_t *q, size_t i)
+maxchild(ps_pqueue_t *q, size_t i)
 {
     size_t child_node = left(i);
 
@@ -109,11 +109,11 @@ maxchild(pqueue_t *q, size_t i)
 
 
 static void
-percolate_down(pqueue_t *q, size_t i)
+percolate_down(ps_pqueue_t *q, size_t i)
 {
     size_t child_node;
     void *moving_node = q->d[i];
-    pqueue_pri_t moving_pri = q->getpri(moving_node);
+    ps_pqueue_pri_t moving_pri = q->getpri(moving_node);
 
     while ((child_node = maxchild(q, i)) &&
            q->cmppri(moving_pri, q->getpri(q->d[child_node])))
@@ -129,7 +129,7 @@ percolate_down(pqueue_t *q, size_t i)
 
 
 int
-pqueue_insert(pqueue_t *q, void *d)
+ps_pqueue_insert(ps_pqueue_t *q, void *d)
 {
     void *tmp;
     size_t i;
@@ -156,12 +156,12 @@ pqueue_insert(pqueue_t *q, void *d)
 
 
 void
-pqueue_change_priority(pqueue_t *q,
-                       pqueue_pri_t new_pri,
+ps_pqueue_change_priority(ps_pqueue_t *q,
+                       ps_pqueue_pri_t new_pri,
                        void *d)
 {
     size_t posn;
-    pqueue_pri_t old_pri = q->getpri(d);
+    ps_pqueue_pri_t old_pri = q->getpri(d);
 
     q->setpri(d, new_pri);
     posn = q->getpos(d);
@@ -173,7 +173,7 @@ pqueue_change_priority(pqueue_t *q,
 
 
 int
-pqueue_remove(pqueue_t *q, void *d)
+ps_pqueue_remove(ps_pqueue_t *q, void *d)
 {
     size_t posn = q->getpos(d);
     q->d[posn] = q->d[--q->size];
@@ -187,7 +187,7 @@ pqueue_remove(pqueue_t *q, void *d)
 
 
 void *
-pqueue_pop(pqueue_t *q)
+ps_pqueue_pop(ps_pqueue_t *q)
 {
     void *head;
 
@@ -203,7 +203,7 @@ pqueue_pop(pqueue_t *q)
 
 
 void *
-pqueue_peek(pqueue_t *q)
+ps_pqueue_peek(ps_pqueue_t *q)
 {
     void *d;
     if (!q || q->size == 1)
@@ -214,9 +214,9 @@ pqueue_peek(pqueue_t *q)
 
 
 void
-pqueue_dump(pqueue_t *q,
+ps_pqueue_dump(ps_pqueue_t *q,
             FILE *out,
-            pqueue_print_entry_f print)
+            ps_pqueue_print_entry_f print)
 {
     int i;
 
@@ -240,21 +240,21 @@ set_pos(void *d, size_t val)
 
 
 static void
-set_pri(void *d, pqueue_pri_t pri)
+set_pri(void *d, ps_pqueue_pri_t pri)
 {
     /* do nothing */
 }
 
 
 void
-pqueue_print(pqueue_t *q,
+ps_pqueue_print(ps_pqueue_t *q,
              FILE *out,
-             pqueue_print_entry_f print)
+             ps_pqueue_print_entry_f print)
 {
-    pqueue_t *dup;
+    ps_pqueue_t *dup;
 	void *e;
 
-    dup = pqueue_init(q->size,
+    dup = ps_pqueue_init(q->size,
                       q->cmppri, q->getpri, set_pri,
                       q->getpos, set_pos);
     dup->size = q->size;
@@ -263,15 +263,15 @@ pqueue_print(pqueue_t *q,
 
     memcpy(dup->d, q->d, (q->size * sizeof(void *)));
 
-    while ((e = pqueue_pop(dup)))
+    while ((e = ps_pqueue_pop(dup)))
 		print(out, e);
 
-    pqueue_free(dup);
+    ps_pqueue_free(dup);
 }
 
 
 static int
-subtree_is_valid(pqueue_t *q, int pos)
+subtree_is_valid(ps_pqueue_t *q, int pos)
 {
     if (left(pos) < q->size) {
         /* has a left child */
@@ -292,7 +292,7 @@ subtree_is_valid(pqueue_t *q, int pos)
 
 
 int
-pqueue_is_valid(pqueue_t *q)
+ps_pqueue_is_valid(ps_pqueue_t *q)
 {
     return subtree_is_valid(q, 1);
 }

--- a/priorityQueue.h
+++ b/priorityQueue.h
@@ -38,36 +38,36 @@ extern "C" {
 #endif
 
 /** priority data type */
-typedef struct timeval pqueue_pri_t;
+typedef struct timeval ps_pqueue_pri_t;
 
 /** callback functions to get/set/compare the priority of an element */
-typedef pqueue_pri_t (*pqueue_get_pri_f)(void *a);
-typedef void (*pqueue_set_pri_f)(void *a, pqueue_pri_t pri);
-typedef int (*pqueue_cmp_pri_f)(pqueue_pri_t next, pqueue_pri_t curr);
+typedef ps_pqueue_pri_t (*ps_pqueue_get_pri_f)(void *a);
+typedef void (*ps_pqueue_set_pri_f)(void *a, ps_pqueue_pri_t pri);
+typedef int (*ps_pqueue_cmp_pri_f)(ps_pqueue_pri_t next, ps_pqueue_pri_t curr);
 
 
 /** callback functions to get/set the position of an element */
-typedef size_t (*pqueue_get_pos_f)(void *a);
-typedef void (*pqueue_set_pos_f)(void *a, size_t pos);
+typedef size_t (*ps_pqueue_get_pos_f)(void *a);
+typedef void (*ps_pqueue_set_pos_f)(void *a, size_t pos);
 
 
 /** debug callback function to print a entry */
-typedef void (*pqueue_print_entry_f)(FILE *out, void *a);
+typedef void (*ps_pqueue_print_entry_f)(FILE *out, void *a);
 
 
 /** the priority queue handle */
-typedef struct pqueue_t
+typedef struct ps_pqueue_t
 {
     size_t size;
     size_t avail;
     size_t step;
-    pqueue_cmp_pri_f cmppri;
-    pqueue_get_pri_f getpri;
-    pqueue_set_pri_f setpri;
-    pqueue_get_pos_f getpos;
-    pqueue_set_pos_f setpos;
+    ps_pqueue_cmp_pri_f cmppri;
+    ps_pqueue_get_pri_f getpri;
+    ps_pqueue_set_pri_f setpri;
+    ps_pqueue_get_pos_f getpos;
+    ps_pqueue_set_pos_f setpos;
     void **d;
-} pqueue_t;
+} ps_pqueue_t;
 
 
 /**
@@ -81,27 +81,27 @@ typedef struct pqueue_t
  *
  * @Return the handle or NULL for insufficent memory
  */
-pqueue_t *
-pqueue_init(size_t n,
-            pqueue_cmp_pri_f cmppri,
-            pqueue_get_pri_f getpri,
-            pqueue_set_pri_f setpri,
-            pqueue_get_pos_f getpos,
-            pqueue_set_pos_f setpos);
+ps_pqueue_t *
+ps_pqueue_init(size_t n,
+            ps_pqueue_cmp_pri_f cmppri,
+            ps_pqueue_get_pri_f getpri,
+            ps_pqueue_set_pri_f setpri,
+            ps_pqueue_get_pos_f getpos,
+            ps_pqueue_set_pos_f setpos);
 
 
 /**
  * free all memory used by the queue
  * @param q the queue
  */
-void pqueue_free(pqueue_t *q);
+void ps_pqueue_free(ps_pqueue_t *q);
 
 
 /**
  * return the size of the queue.
  * @param q the queue
  */
-size_t pqueue_size(pqueue_t *q);
+size_t ps_pqueue_size(ps_pqueue_t *q);
 
 
 /**
@@ -110,7 +110,7 @@ size_t pqueue_size(pqueue_t *q);
  * @param d the item
  * @return 0 on success
  */
-int pqueue_insert(pqueue_t *q, void *d);
+int ps_pqueue_insert(ps_pqueue_t *q, void *d);
 
 
 /**
@@ -120,8 +120,8 @@ int pqueue_insert(pqueue_t *q, void *d);
  * @param d the entry
  */
 void
-pqueue_change_priority(pqueue_t *q,
-                       pqueue_pri_t new_pri,
+ps_pqueue_change_priority(ps_pqueue_t *q,
+                       ps_pqueue_pri_t new_pri,
                        void *d);
 
 
@@ -131,7 +131,7 @@ pqueue_change_priority(pqueue_t *q,
  * @param d where to copy the entry to
  * @return NULL on error, otherwise the entry
  */
-void *pqueue_pop(pqueue_t *q);
+void *ps_pqueue_pop(ps_pqueue_t *q);
 
 
 /**
@@ -140,7 +140,7 @@ void *pqueue_pop(pqueue_t *q);
  * @param d the entry
  * @return 0 on success
  */
-int pqueue_remove(pqueue_t *q, void *d);
+int ps_pqueue_remove(ps_pqueue_t *q, void *d);
 
 
 /**
@@ -149,7 +149,7 @@ int pqueue_remove(pqueue_t *q, void *d);
  * @param d the entry
  * @return NULL on error, otherwise the entry
  */
-void *pqueue_peek(pqueue_t *q);
+void *ps_pqueue_peek(ps_pqueue_t *q);
 
 
 /**
@@ -161,9 +161,9 @@ void *pqueue_peek(pqueue_t *q);
  * @param the callback function to print the entry
  */
 void
-pqueue_print(pqueue_t *q,
+ps_pqueue_print(ps_pqueue_t *q,
              FILE *out,
-             pqueue_print_entry_f print);
+             ps_pqueue_print_entry_f print);
 
 
 /**
@@ -175,9 +175,9 @@ pqueue_print(pqueue_t *q,
  * @param the callback function to print the entry
  */
 void
-pqueue_dump(pqueue_t *q,
+ps_pqueue_dump(ps_pqueue_t *q,
              FILE *out,
-             pqueue_print_entry_f print);
+             ps_pqueue_print_entry_f print);
 
 
 /**
@@ -186,7 +186,7 @@ pqueue_dump(pqueue_t *q,
  * debug function only
  * @param q the queue
  */
-int pqueue_is_valid(pqueue_t *q);
+int ps_pqueue_is_valid(ps_pqueue_t *q);
 
 #ifdef __cplusplus
 }

--- a/proclib.h
+++ b/proclib.h
@@ -103,7 +103,10 @@ struct XDR_CommandHandlers {
  */
 ProcessData *PROC_init_xdr(const char *procName, enum WatchdogMode wdMode,
       struct XDR_CommandHandlers *handlers);
+ProcessData *PROC_init_xdr_hashsize(const char *procName, enum WatchdogMode wdMode,
+      struct XDR_CommandHandlers *handlers, int sz);
 ProcessData *PROC_init(const char *procName, enum WatchdogMode wdMode);
+ProcessData *PROC_init_hashsize(const char *procName, enum WatchdogMode wdMode, int hashsize);
 
 /**
  * Registers the process with the software watchdog.

--- a/util.c
+++ b/util.c
@@ -172,7 +172,7 @@ int UTIL_cleanup_dir(const char *dirname, int max_entries, int ignore_hidden,
 {
    DIR *dir = NULL;
    struct dirent *prev_ent = NULL;
-   pqueue_t *queue = NULL;
+   ps_pqueue_t *queue = NULL;
    struct CleanupState *cleanup_records = NULL, *next_rec = NULL;
    int res = 0;
    char *path_buff = NULL;
@@ -201,7 +201,7 @@ int UTIL_cleanup_dir(const char *dirname, int max_entries, int ignore_hidden,
 
    // Pre-allocate a pqueue (efficient data structure for keeping entries
    //  sorted) to hold max + 5 entries
-   queue = pqueue_init(max_entries + 5, cmp_pri_cleanup_state,
+   queue = ps_pqueue_init(max_entries + 5, cmp_pri_cleanup_state,
       get_pri_cleanup_state, set_pri_cleanup_state,
       get_pos_cleanup_state, set_pos_cleanup_state);
 
@@ -262,13 +262,13 @@ int UTIL_cleanup_dir(const char *dirname, int max_entries, int ignore_hidden,
       }
 
       // Add the file into our queue
-      pqueue_insert(queue, next_rec);
+      ps_pqueue_insert(queue, next_rec);
 
       // If the queue is too big (> max_entries), dequeue oldest entry,
       //  delete it, and reuse entry storage for next iteration through
       //  the readdir() loop
-      if (pqueue_size(queue) > max_entries) {
-         next_rec = pqueue_pop(queue);
+      if (ps_pqueue_size(queue) > max_entries) {
+         next_rec = ps_pqueue_pop(queue);
          if (!next_rec) {
             ERR_REPORT(DBG_LEVEL_WARN, "pqueue internal error.  pop on non-empty queue didn't return record\n");
             res = -1;
@@ -319,7 +319,7 @@ cleanup:
       closedir(dir);
 
    if (queue)
-      pqueue_free(queue);
+      ps_pqueue_free(queue);
 
    if (cleanup_records)
       free(cleanup_records);

--- a/xdr-saved.h
+++ b/xdr-saved.h
@@ -1,0 +1,358 @@
+#ifndef XDR_H
+#define XDR_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "proclib.h"
+
+struct XDR_FieldDefinition;
+
+#ifndef XDR_PRINT_STYLE_ENUM
+#define XDR_PRINT_STYLE_ENUM
+#ifdef __cplusplus
+enum XDR_PRINT_STYLE : short { XDR_PRINT_HUMAN, XDR_PRINT_KVP, XDR_PRINT_CSV_HEADER,
+   XDR_PRINT_CSV_DATA };
+
+#else
+enum XDR_PRINT_STYLE { XDR_PRINT_HUMAN, XDR_PRINT_KVP, XDR_PRINT_CSV_HEADER,
+   XDR_PRINT_CSV_DATA };
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int (*XDR_Decoder)(char *src, void *dst, size_t *inc, size_t max,
+      void *len);
+typedef int (*XDR_Encoder)(char *src, void *dst, size_t *inc, size_t max,
+      void *len);
+typedef void (*XDR_print_func)(FILE *out, void *data, void *arg, const char *,
+      enum XDR_PRINT_STYLE style, int *line, int level);
+typedef void (*XDR_print_field_func)(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *len, int *line, int level);
+typedef double (*XDR_conversion_func)(double);
+typedef void (*XDR_field_scanner)(const char *in, void *dst, void *arg,
+      void *len, XDR_conversion_func conv);
+typedef void (*XDR_tx_struct)(void *data, void *arg, uint32_t error);
+typedef void (*XDR_populate_struct)(void *arg, XDR_tx_struct cb, void *cb_arg);
+
+struct XDR_Union {
+   uint32_t type;
+   void *data;
+};
+
+struct XDR_TypeFunctions {
+   XDR_Decoder decoder;
+   XDR_Encoder encoder;
+   XDR_print_field_func printer;
+   XDR_field_scanner scanner;
+   void (*field_dealloc)(void **, struct XDR_FieldDefinition *field);
+};
+
+struct XDR_FieldDefinition {
+   struct XDR_TypeFunctions *funcs;
+   size_t offset;
+   const char *key;
+   const char *name;
+   const char *unit;
+   XDR_conversion_func conversion;
+   XDR_conversion_func inverse_conv;
+   uint32_t struct_id;
+   const char *description;
+   size_t len_offset;
+};
+
+struct XDR_StructDefinition {
+   uint32_t type;
+   size_t in_memory_size;
+   int (*encoder)(void *src, char *dst, size_t *inc, size_t max,
+         uint32_t type, void *arg);
+   int (*decoder)(char *src, void *dst, size_t *used, size_t max, void *arg);
+   void *arg;
+   void *(*allocator)(struct XDR_StructDefinition *def);
+   void (*deallocator)(void **goner, struct XDR_StructDefinition *def);
+   XDR_print_func print_func;
+   XDR_populate_struct populate;
+   void *populate_arg;
+};
+
+extern void XDR_register_structs(struct XDR_StructDefinition*);
+extern void XDR_register_struct(struct XDR_StructDefinition*);
+extern void XDR_register_populator(XDR_populate_struct cb,
+      void *arg, uint32_t type);
+extern struct XDR_StructDefinition *XDR_definition_for_type(uint32_t type);
+extern void XDR_set_struct_print_function(XDR_print_func func, uint32_t type);
+extern void XDR_set_field_print_function(XDR_print_field_func func,
+      uint32_t struct_type, uint32_t field);
+
+extern int XDR_array_encoder(char *src, void *dst, size_t *used, size_t max,
+      int len, size_t increment, XDR_Encoder enc, void *enc_arg);
+extern int XDR_array_decoder(char *src, void *dst, size_t *used, size_t max,
+      int len, size_t increment, XDR_Decoder dec, void *dec_arg);
+extern int XDR_struct_encoder(void *src, char *dst, size_t *encoded_size,
+      size_t max, uint32_t type, void *arg);
+extern int XDR_bitfield_struct_encoder(void *src, char *dst,
+      size_t *encoded_size, size_t max, uint32_t type, void *arg);
+extern void XDR_print_structure(uint32_t type,
+      struct XDR_StructDefinition *str, char *buff, size_t len, void *arg1,
+      int arg2, const char *parent);
+extern void XDR_array_field_printer(FILE *out, void *src_ptr,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      void *len_ptr, XDR_print_field_func print, size_t increment,
+      const char *parent, int *line, int level);
+extern void XDR_array_field_scanner(const char *in, void *dst_ptr, void *arg,
+      void *len_ptr, XDR_field_scanner scan, void *enc_arg,
+      size_t increment, XDR_conversion_func conv);
+extern void XDR_print_fields_func(FILE *out, void *data, void *arg,
+      const char*, enum XDR_PRINT_STYLE style, int *line, int level);
+
+
+// All decoder functions take the exact same set of parameters to
+//  permit more efficient, generic parsing code
+//
+// The parameters are:
+//  char *src -- The address to start decoding from
+//  void *dst -- The address to store the decoded data.  The structure of this 
+//                memory will be type dependent
+//  size_t *used -- Out parameter that returns the number of bytes used from
+//                    the src buffer
+//  size_t max -- The total number of bytes available in the src buffer
+//
+//  Returns negative number on error, or 0 on success.  Positive numbers are
+//     reserved for future use
+extern int XDR_struct_decoder(char *src, void *dst, size_t *used,
+      size_t max, void *arg);
+extern int XDR_bitfield_struct_decoder(char *src, void *dst, size_t *used,
+      size_t max, void *arg);
+extern int XDR_decodebf_int32(char *src, int32_t *dst, size_t *used,
+      size_t max, void *len);
+extern int XDR_decodebf_uint32(char *src, uint32_t *dst, size_t *used,
+      size_t max, void *len);
+extern int XDR_decode_int32(char *src, int32_t *dst, size_t *used, size_t max,
+      void *len);
+extern int XDR_decode_uint32(char *src, uint32_t *dst, size_t *used,
+      size_t max, void *len);
+extern int XDR_decode_int64(char *src, int64_t *dst, size_t *used, size_t max,
+      void *len);
+extern int XDR_decode_uint64(char *src, uint64_t *dst, size_t *used,
+      size_t max, void *len);
+extern int XDR_decode_float(char *src, float *dst, size_t *used, size_t max,
+      void *len);
+extern int XDR_decode_double(char *src, double *dst, size_t *used, size_t max,
+      void *len);
+extern int XDR_decode_union(char *src, struct XDR_Union *dst, size_t *used,
+      size_t max, void *len);
+extern int XDR_decode_string(char *src, char **dst, size_t *used,
+      size_t max, void *len);
+
+extern int XDR_decode_byte_array(char *src, char **dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_decode_uint32_array(char *src, uint32_t **dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_decode_int32_array(char *src, int32_t **dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_decode_int64_array(char *src, int64_t **dst, size_t *used,
+      size_t max, void *len);
+extern int XDR_decode_uint64_array(char *src, uint64_t **dst, size_t *used,
+      size_t max, void *len);
+extern int XDR_decode_float_array(char *src, float **dst, size_t *used,
+      size_t max, void *len);
+extern int XDR_decode_double_array(char *src, double **dst, size_t *used,
+      size_t max, void *len);
+extern int XDR_decode_union_array(char *src, struct XDR_Union **dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_decode_string_array(char *src, char **dst,
+      size_t *used, size_t max, void *len);
+
+// Encode functions
+extern int XDR_encodebf_uint32(uint32_t *src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_uint32(uint32_t *src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_int32(int32_t *src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_int64(int64_t *src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_uint64(uint64_t *src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_union(struct XDR_Union *src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_string(const char *src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_float(float *src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_double(double *src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_byte_array(char **src, char *dst,
+      size_t *used, size_t max, void *len);
+
+extern int XDR_encode_uint32_array(uint32_t **src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_int32_array(int32_t **src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_int64_array(int64_t **src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_uint64_array(uint64_t **src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_union_array(struct XDR_Union **src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_float_array(float **src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_double_array(double **src, char *dst,
+      size_t *used, size_t max, void *len);
+extern int XDR_encode_string_array(const char **src, char *dst,
+      size_t *used, size_t max, void *len);
+
+extern void *XDR_malloc_allocator(struct XDR_StructDefinition*);
+extern void XDR_free_deallocator(void **goner, struct XDR_StructDefinition *);
+extern void XDR_struct_free_deallocator(void **goner,
+      struct XDR_StructDefinition *def);
+extern void XDR_struct_field_deallocator(void **goner,
+      struct XDR_FieldDefinition *field);
+extern void XDR_struct_array_field_deallocator(void **goner,
+      struct XDR_FieldDefinition *field);
+extern void XDR_array_field_deallocator(void **goner,
+      struct XDR_FieldDefinition *field);
+extern void XDR_union_field_deallocator(void **goner,
+      struct XDR_FieldDefinition *field);
+extern void XDR_union_array_field_deallocator(void **goner,
+      struct XDR_FieldDefinition *field);
+extern void XDR_free_union(struct XDR_Union *goner);
+
+extern void XDR_print_field_char(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_int32(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_uint32(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_int64(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_uint64(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_union(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_byte_string(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_string(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_float(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_double(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style, 
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_structure(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *len, int *line, int level);
+
+extern void XDR_print_field_structure_array(FILE *out, void *src_ptr,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      void *len_ptr, size_t increment, const char *parent, int *line, int level);
+extern void XDR_print_field_char_array(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *len, int *line, int level);
+extern void XDR_print_field_int32_array(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *len, int *line, int level);
+extern void XDR_print_field_uint32_array(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *len, int *line, int level);
+extern void XDR_print_field_int64_array(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *len, int *line, int level);
+extern void XDR_print_field_uint64_array(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *len, int *line, int level);
+extern void XDR_print_field_union_array(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *len, int *line, int level);
+extern void XDR_print_field_byte_array(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *, int *line, int level);
+extern void XDR_print_field_float_array(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *len, int *line, int level);
+extern void XDR_print_field_double_array(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *len, int *line, int level);
+extern void XDR_print_field_string_array(FILE *out, void *data,
+      struct XDR_FieldDefinition *field, enum XDR_PRINT_STYLE style,
+      const char *parent, void *len, int *line, int level);
+
+extern void XDR_scan_float(const char *in, void *dst, void *arg, void *len,
+      XDR_conversion_func conv);
+extern void XDR_scan_double(const char *in, void *dst, void *arg, void *len,
+      XDR_conversion_func conv);
+extern void XDR_scan_char(const char *in, void *dst, void *arg, void *len,
+      XDR_conversion_func conv);
+extern void XDR_scan_int32(const char *in, void *dst, void *arg, void *len,
+      XDR_conversion_func conv);
+extern void XDR_scan_uint32(const char *in, void *dst, void *arg, void *len,
+      XDR_conversion_func conv);
+extern void XDR_scan_int64(const char *in, void *dst, void *arg, void *len,
+      XDR_conversion_func conv);
+extern void XDR_scan_uint64(const char *in, void *dst, void *arg, void *len,
+      XDR_conversion_func conv);
+extern void XDR_scan_string(const char *in, void *dst, void *arg, void *len,
+      XDR_conversion_func conv);
+extern void XDR_scan_byte(const char *in, void *dst, void *arg, void *len,
+      XDR_conversion_func conv);
+
+extern void XDR_scan_float_array(const char *in, void *dst, void *arg,
+      void *len, XDR_conversion_func conv);
+extern void XDR_scan_double_array(const char *in, void *dst, void *arg,
+      void *len, XDR_conversion_func conv);
+extern void XDR_scan_char_array(const char *in, void *dst, void *arg,
+      void *len, XDR_conversion_func conv);
+extern void XDR_scan_int32_array(const char *in, void *dst, void *arg,
+      void *len, XDR_conversion_func conv);
+extern void XDR_scan_uint32_array(const char *in, void *dst, void *arg,
+      void *len, XDR_conversion_func conv);
+extern void XDR_scan_int64_array(const char *in, void *dst, void *arg,
+      void *len, XDR_conversion_func conv);
+extern void XDR_scan_uint64_array(const char *in, void *dst, void *arg,
+      void *len, XDR_conversion_func conv);
+extern void XDR_scan_string_array(const char *in, void *dst, void *arg,
+      void *len, XDR_conversion_func conv);
+extern void XDR_scan_byte_array(const char *in, void *dst, void *arg,
+      void *len, XDR_conversion_func conv);
+
+extern struct XDR_TypeFunctions xdr_float_functions;
+extern struct XDR_TypeFunctions xdr_float_arr_functions;
+extern struct XDR_TypeFunctions xdr_double_functions;
+extern struct XDR_TypeFunctions xdr_double_arr_functions;
+extern struct XDR_TypeFunctions xdr_char_functions;
+extern struct XDR_TypeFunctions xdr_char_arr_functions;
+extern struct XDR_TypeFunctions xdr_int32_functions;
+extern struct XDR_TypeFunctions xdr_int32_arr_functions;
+extern struct XDR_TypeFunctions xdr_uint32_functions;
+extern struct XDR_TypeFunctions xdr_uint32_arr_functions;
+extern struct XDR_TypeFunctions xdr_int64_functions;
+extern struct XDR_TypeFunctions xdr_int64_arr_functions;
+extern struct XDR_TypeFunctions xdr_uint64_functions;
+extern struct XDR_TypeFunctions xdr_uint64_arr_functions;
+extern struct XDR_TypeFunctions xdr_string_functions;
+extern struct XDR_TypeFunctions xdr_string_arr_functions;
+extern struct XDR_TypeFunctions xdr_byte_arr_functions;
+extern struct XDR_TypeFunctions xdr_union_functions;
+extern struct XDR_TypeFunctions xdr_union_arr_functions;
+extern struct XDR_TypeFunctions xdr_int32_bitfield_functions;
+extern struct XDR_TypeFunctions xdr_uint32_bitfield_functions;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/xdr.h
+++ b/xdr.h
@@ -9,14 +9,19 @@
 
 struct XDR_FieldDefinition;
 
+#ifndef XDR_PRINT_STYLE_ENUM
+#define XDR_PRINT_STYLE_ENUM
 #ifdef __cplusplus
-enum XDR_PRINT_STYLE : short { XDR_PRINT_HUMAN, XDR_PRINT_KVP, XDR_PRINT_CSV_HEADER,
-   XDR_PRINT_CSV_DATA };
-
-extern "C" {
+enum XDR_PRINT_STYLE : short { XDR_PRINT_HUMAN, XDR_PRINT_KVP, XDR_PRINT_CSV_HEA
+DER, XDR_PRINT_CSV_DATA };
 #else
 enum XDR_PRINT_STYLE { XDR_PRINT_HUMAN, XDR_PRINT_KVP, XDR_PRINT_CSV_HEADER,
    XDR_PRINT_CSV_DATA };
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 struct XDR_Dictionary;


### PR DESCRIPTION
- Rename psqueue to ps_psqueue to avoid conflicts with ubuntu headers.
- Don't crash when started without a process name.