### PR TITLE
Debug level changed from WARN to FATAL.

### DIFF
--- a/ipc.c
+++ b/ipc.c
@@ -93,7 +93,8 @@ int socket_named_init(const char * service)
       DBG_print(DBG_LEVEL_INFO, "Binding socket on port %u\n", portNum);
       fd = socket_init(portNum);
    } else {
-      DBG_print(DBG_LEVEL_WARN, "Failed to look up %s port number\n", service);
+      DBG_print(DBG_LEVEL_FATAL, "FATAL: Failed to look up %s port number\n", service);
+      exit(4);
    }
 
    return fd;


### PR DESCRIPTION
When a client initaliazed libproc, `PROC_init_xdr` or `PROC_init` is called to initialize libproc. If the name of the process is not found in /etc/services, there is a backup lookup table in `ipc.c` detailing the port, ip address, etc. to use for each process. However, if the process listing does not exist in both places, `socket_get_addr_by_name()` and `socket_named_init()` will warn tht the service lookup failed. When this happends, `socket_named_init()` returns an invalid file descriptor, which is passed into `proc->cmdFd`. Since `proc->cmdFd` is never validated, a segmentation fault occurs when attempting to access the file descriptor.

This PR changes the debug level in `socket_named_init()` from WARN to FATAL when `socket_get_addr_by_name()` returns an invalid port. Additionally, it will exit with A non-zero code, preventing the segfault.