### PR TITLE
Fix Mac OS monotonic time compilation error

### DIFF
--- a/eventTimer.c
+++ b/eventTimer.c
@@ -152,8 +152,9 @@ int ET_rtdebug_monotonic(struct EventTimer *arg, struct timeval *tv)
 
    #ifdef __APPLE__
 
-   res = 0
-   gettimeofday(now, NULL)
+   res = 0;
+   // WARNING: Not a monotonic clock, simply a stub for Apple devices.
+   gettimeofday(&now, NULL);
 
    #else
 


### PR DESCRIPTION
Note that the Mac OS implementation isn't actually monotonic, but a stub that simply returns the wall clock.

While this should be fixed, it's good enough for development on Mac OS, since the edge cases where the monotonic time differs from wall clock are rare enough that they 
don't interfere with development.